### PR TITLE
Add 2FA revalidation

### DIFF
--- a/inc/class-session-controller.php
+++ b/inc/class-session-controller.php
@@ -221,9 +221,7 @@ class Session_Controller extends WP_REST_Controller {
 
 		// If the 2FA plugin is active, validate the 2fa part of the request.
 		$valid_2fa = $this->validate_2fa( $request, $user );
-
 		if ( is_wp_error( $valid_2fa ) ) {
-			// wp_clear_auth_cookie();
 			return $valid_2fa;
 		}
 


### PR DESCRIPTION
This updates the login process to correctly store the 2FA provider and time, and adds a new revalidation endpoint. These are necessary when updating the 2FA settings, which requires revalidation in order to update if more than 10 mins (by default) has elapsed since logging in (i.e. a type of "sudo mode").