### PR TITLE
Allow any 2FA provider on revalidation

### DIFF
--- a/inc/class-session-controller.php
+++ b/inc/class-session-controller.php
@@ -212,8 +212,7 @@ class Session_Controller extends WP_REST_Controller {
 		$manager = WP_Session_Tokens::get_instance( $user->ID );
 		$session = $manager->get( $token );
 
-		$provider_class = static::NAME_MAP[ $request['2fa']['provider'] ] ?? null;
-		if ( $provider_class !== $session['two-factor-provider'] ) {
+		if ( empty( $session['two-factor-provider'] ) ) {
 			// Force a bad 2FA to return the challenge.
 			$not_request = [];
 			return $this->validate_2fa( $not_request, $user );


### PR DESCRIPTION
Users can already just log out and back in anyway, so no point requiring the same method.